### PR TITLE
sign: check if the http request body is empty

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -181,7 +181,7 @@ func (s *Signature) generateSigningKey(secret string) {
 // If the signature was created on a different UTC day the signing will be
 // invalid.
 // The optional payload allows for various methods to hash the request's body.
-// If no playload is supplied the body is copyed into memory to be hashed.
+// If no payload is supplied the body is copyed into memory to be hashed.
 //
 // Possible errors are an invalid URL query parameters (url.EscapeError), if
 // the date header isn't in time.RFC1123 format (*time.ParseError), or an error
@@ -304,13 +304,16 @@ func (s *Signature) Sign(r *http.Request, payload Payload) error {
 	// or HTTPS request.
 	//
 	if payload == nil {
-		mem, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			return err
-		}
-		err = r.Body.Close()
-		if err != nil {
-			return err
+		var mem []byte
+		if r.Body != nil {
+			mem, err = ioutil.ReadAll(r.Body)
+			if err != nil {
+				return err
+			}
+			err = r.Body.Close()
+			if err != nil {
+				return err
+			}
 		}
 		payload = MemoryPayload(mem)
 	}


### PR DESCRIPTION
Commands using an empty request body will panic:

$ ./glacier vault list us-east-1
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x20 pc=0x44e6fd]

goroutine 1 [running]:
io/ioutil.func·001()
        /home/msantos/src/3rd/go/src/pkg/io/ioutil/ioutil.go:29 +0xee
bytes.(_Buffer).ReadFrom(0xc2000c8380, 0x0, 0x0, 0x0, 0x0, ...)
        /home/msantos/src/3rd/go/src/pkg/bytes/buffer.go:169 +0x1fd
io/ioutil.readAll(0x0, 0x0, 0x200, 0x0, 0x0, ...)
        /home/msantos/src/3rd/go/src/pkg/io/ioutil/ioutil.go:32 +0x143
io/ioutil.ReadAll(0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /home/msantos/src/3rd/go/src/pkg/io/ioutil/ioutil.go:41 +0x3d
github.com/rdwilliamson/aws.(_Signature).Sign(0xc2000d00c0, 0xc2000b5680, 0x0, 0x0, 0xa, ...)
        /home/msantos/src/golang/gocode/src/github.com/rdwilliamson/aws/aws.go:307 +0xf3d
github.com/rdwilliamson/aws/glacier.(*Connection).ListVaults(0xc2000de300, 0x6cb1a0, 0x0, 0x0, 0x0, ...)
        /home/msantos/src/golang/gocode/src/github.com/rdwilliamson/aws/glacier/vault.go:206 +0x2a5
main.vault(0xc200092040, 0x1, 0x1)
        /home/msantos/src/golang/gocode/src/github.com/rdwilliamson/glacier/vault.go:53 +0x9c8
main.main()
        /home/msantos/src/golang/gocode/src/github.com/rdwilliamson/glacier/main.go:82 +0x89f

goroutine 2 [syscall]:

goroutine 3 [runnable]:
