### PR TITLE
Solved problem with "Too many open files"

### DIFF
--- a/glacier/archive.go
+++ b/glacier/archive.go
@@ -2,6 +2,7 @@ package glacier
 
 import (
 	"io"
+	"io/ioutil"
 	"net/http"
 	"path"
 
@@ -47,11 +48,12 @@ func (c *Connection) UploadArchive(vault string, archive io.ReadSeeker, descript
 		return "", err
 	}
 	defer response.Body.Close()
-	io.Copy(ioutil.Discard, response.Body)
 
 	if response.StatusCode != http.StatusCreated {
 		return "", aws.ParseError(response)
 	}
+
+	io.Copy(ioutil.Discard, response.Body)
 
 	// Parse success response.
 	_, location := path.Split(response.Header.Get("Location"))
@@ -81,6 +83,8 @@ func (c *Connection) DeleteArchive(vault, archive string) error {
 	if response.StatusCode != http.StatusNoContent {
 		return aws.ParseError(response)
 	}
+
+	io.Copy(ioutil.Discard, response.Body)
 
 	// Parse success response.
 	return nil

--- a/glacier/multipart.go
+++ b/glacier/multipart.go
@@ -94,6 +94,8 @@ func (c *Connection) InitiateMultipart(vault string, size int64, description str
 		return "", aws.ParseError(response)
 	}
 
+	io.Copy(ioutil.Discard, response.Body)
+
 	// Parse success response.
 	return response.Header.Get("x-amz-multipart-upload-id"), nil
 }
@@ -170,6 +172,8 @@ func (c *Connection) UploadMultipart(vault, uploadId string, start int64, body i
 		return aws.ParseError(response)
 	}
 
+	io.Copy(ioutil.Discard, response.Body)
+
 	// Parse success response.
 	return nil
 }
@@ -232,6 +236,8 @@ func (c *Connection) CompleteMultipart(vault, uploadId, treeHash string, size in
 		return "", aws.ParseError(response)
 	}
 
+	io.Copy(ioutil.Discard, response.Body)
+
 	// Parse success response.
 	return response.Header.Get("x-amz-archive-id"), nil
 }
@@ -265,6 +271,8 @@ func (c *Connection) AbortMultipart(vault, uploadId string) error {
 	if response.StatusCode != http.StatusNoContent {
 		return aws.ParseError(response)
 	}
+
+	io.Copy(ioutil.Discard, response.Body)
 
 	// Parse success response.
 	return nil

--- a/glacier/vault.go
+++ b/glacier/vault.go
@@ -3,6 +3,7 @@ package glacier
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -77,6 +78,8 @@ func (c *Connection) CreateVault(name string) error {
 		return aws.ParseError(response)
 	}
 
+	io.Copy(ioutil.Discard, response.Body)
+
 	// Parse success response.
 	return nil
 }
@@ -108,6 +111,8 @@ func (c *Connection) DeleteVault(name string) error {
 	if response.StatusCode != http.StatusNoContent {
 		return aws.ParseError(response)
 	}
+
+	io.Copy(ioutil.Discard, response.Body)
 
 	// Parse success response.
 	return nil
@@ -300,6 +305,8 @@ func (c *Connection) SetVaultNotifications(name string, n *Notifications) error 
 		return aws.ParseError(response)
 	}
 
+	io.Copy(ioutil.Discard, response.Body)
+
 	// Parse success response.
 	return nil
 }
@@ -371,6 +378,8 @@ func (c *Connection) DeleteVaultNotifications(name string) error {
 	if response.StatusCode != http.StatusNoContent {
 		return aws.ParseError(response)
 	}
+
+	io.Copy(ioutil.Discard, response.Body)
 
 	// Parse success response.
 	return nil


### PR DESCRIPTION
I've built a glacier backup program in Go (https://github.com/rpkamp/gobackup) using your excellent library, but I ran into a problem that after a few hundred uploads I would get the error 'Too many open files' and the whole thing would come crumbling down and refuse to upload anything from that point forward.

I'd checked my code several times and I couldn't find a leak where I'd leave file descriptors hanging. So I dug in to it some more and found that `http.Client` may not re-use connections if you don't fully consume the response (see http://stackoverflow.com/questions/17948827/reusing-http-connections-in-golang in the first answer by Matt Self).

I saw in `aws.Connection.UploadArchive()` that you are currently not consuming the response of the request at all, so I was guessing that that was the reason for my 'Too many open files' problem.

So I added the code to drain the response (by simply copying it to `io.Discard` since I'm not interested in it), recompiled, and voila, I've got 2 connections open to glacier which are constantly being reused for new files, and no more 'Too many open files'. At least I've yet to see one :)
