### PR TITLE
Adding AWS-enabled tests and TreeHashFromMultipartUpload helper function...

### DIFF
--- a/glacier/README.md
+++ b/glacier/README.md
@@ -1,0 +1,15 @@
+Some of the tests require AWS credentials to be set, as they upload to Glacier.
+If the following environment variables are not set, those tests will be skipped:
+
+```
+AWS_SECRET_KEY
+AWS_ACCESS_KEY
+GLACIER_VAULT
+GLACIER_REGION
+```
+
+Use `go test -v` to see which tests are run and which are skipped.
+
+The tests make the best effort to cleanup uploaded archives. If you set these
+credentials correctly and run the tests, you will incur request and storage
+pricing (http://aws.amazon.com/glacier/pricing/).

--- a/glacier/multipart_test.go
+++ b/glacier/multipart_test.go
@@ -1,0 +1,124 @@
+package glacier
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rdwilliamson/aws"
+)
+
+const (
+	envAWSAccess     = "AWS_ACCESS_KEY"
+	envAWSSecret     = "AWS_SECRET_KEY"
+	envGlacierVault  = "GLACIER_VAULT"
+	envGlacierRegion = "GLACIER_REGION"
+)
+
+// aReader returns "a" ad infinitum
+type aReader struct{}
+
+func (x *aReader) Read(p []byte) (n int, err error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	return len(p), nil
+}
+
+func TestSmallFewParts(t *testing.T) {
+	testUpload(t, rand.Reader, 3, 1<<20)
+}
+
+func TestSmallManyParts(t *testing.T) {
+	testUpload(t, rand.Reader, 50, 1<<20)
+}
+
+func TestMediumParts(t *testing.T) {
+	testUpload(t, rand.Reader, 3, 4<<20)
+}
+
+func TestHugeParts(t *testing.T) {
+	x := aReader{}
+	testUpload(t, &x, 2, 256<<20)
+}
+
+// testUpload only runs if AWS credentials and Glacier parameters
+// are set. It uploads nParts+1 parts; nParts of size partSize, and a final
+// one of size (3/4)*partSize.
+func testUpload(t *testing.T, r io.Reader, nParts int, partSize int64) {
+	secret, access := aws.KeysFromEnviroment()
+	vault := os.Getenv(envGlacierVault)
+	regionStr := os.Getenv(envGlacierRegion)
+	if secret == "" || access == "" {
+		t.Skipf("%s or %s is not provided.", envAWSAccess, envAWSSecret)
+	}
+	if vault == "" {
+		t.Skipf("%s is not provided.", envGlacierVault)
+	}
+	if regionStr == "" {
+		t.Skipf("%s is not provided.", envGlacierRegion)
+	}
+	var region *aws.Region
+	for _, r := range aws.Regions {
+		if r.Name == regionStr {
+			region = r
+			break
+		}
+	}
+	if region == nil {
+		t.Skipf("%s is invalid.", envGlacierRegion)
+	}
+	description := fmt.Sprintf("multipart-upload-test-%d", time.Now().UnixNano())
+	conn := NewConnection(secret, access, region)
+	// Add 3/4ths of a part to simulate a uneven read.
+	toRead := int64(nParts)*partSize + partSize>>1 + partSize>>2
+	nParts++
+	uploadID, err := conn.InitiateMultipart(vault, partSize, description)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var totalRead int64
+	for i := 0; i < nParts; i++ { // Upload each part sequentially.
+		size := partSize
+		if i == nParts-1 { // Last, uneven part
+			size = toRead % partSize
+		}
+		data := make([]byte, 0, size)
+		b := bytes.NewBuffer(data)
+		read, err := io.CopyN(b, r, size)
+		if err != nil {
+			t.Fatal(err)
+		}
+		totalRead += read
+		partR := bytes.NewReader(b.Bytes())
+		err = conn.UploadMultipart(vault, uploadID, int64(i)*partSize, partR)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if totalRead != toRead {
+		t.Errorf("Expected %d data read, got %d", toRead, totalRead)
+	}
+	// Build the treehash from the parts, complete the multipart upload.
+	th, err := conn.TreeHashFromMultipartUpload(vault, uploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	archiveID, err := conn.CompleteMultipart(vault, uploadID, th, toRead)
+	// Cleanup by aborting or deleting the archive, depending on completion status.
+	if err != nil {
+		secondErr := conn.AbortMultipart(vault, uploadID)
+		if secondErr != nil {
+			t.Fatal(secondErr)
+		}
+		t.Fatal(err)
+	}
+	err = conn.DeleteArchive(vault, archiveID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
This adds tests and a helper function that I suspect will be commonly used (at least it is for me). It won't run tests if the environment variables aren't set. For example, when not set:

```
--- aws/glacier ‹master› » go test -v
=== RUN TestGetInventoryJob
--- PASS: TestGetInventoryJob (0.00s)
=== RUN TestListJobs
--- PASS: TestListJobs (0.00s)
=== RUN TestSmallFewParts
--- SKIP: TestSmallFewParts (0.00s)
        multipart_test.go:57: AWS_ACCESS_KEY or AWS_SECRET_KEY is not provided.
=== RUN TestSmallManyParts
--- SKIP: TestSmallManyParts (0.00s)
        multipart_test.go:57: AWS_ACCESS_KEY or AWS_SECRET_KEY is not provided.
=== RUN TestMediumParts
--- SKIP: TestMediumParts (0.00s)
        multipart_test.go:57: AWS_ACCESS_KEY or AWS_SECRET_KEY is not provided.
=== RUN TestHugeParts
--- SKIP: TestHugeParts (0.00s)
        multipart_test.go:57: AWS_ACCESS_KEY or AWS_SECRET_KEY is not provided.
=== RUN TestMultiTreeHasher
--- PASS: TestMultiTreeHasher (0.00s)
=== RUN TestTreeHash
--- PASS: TestTreeHash (0.31s)
=== RUN TestTreeHashCloseEmpty
--- PASS: TestTreeHashCloseEmpty (0.00s)
PASS
ok      github.com/recursionpharma/aws/glacier  0.314s
--- aws/glacier ‹master› » 
```

When set,
```
--- aws/glacier ‹master› » go test -v
=== RUN TestGetInventoryJob
--- PASS: TestGetInventoryJob (0.00s)
=== RUN TestListJobs
--- PASS: TestListJobs (0.00s)
=== RUN TestMiniUpload
--- PASS: TestMiniUpload (4.03s)
=== RUN TestSmallParts
--- PASS: TestSmallParts (60.85s)
=== RUN TestMediumParts
--- PASS: TestMediumParts (33.00s)
=== RUN TestHugeParts
--- PASS: TestHugeParts (243.94s)
=== RUN TestMultiTreeHasher
--- PASS: TestMultiTreeHasher (0.00s)
=== RUN TestTreeHash
--- PASS: TestTreeHash (0.25s)
=== RUN TestTreeHashCloseEmpty
--- PASS: TestTreeHashCloseEmpty (0.00s)
PASS
ok      github.com/recursionpharma/aws/glacier  342.246s
```